### PR TITLE
Fix dependency issues in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,8 +38,8 @@ google-generativeai>=0.3.0
 prometheus-client>=0.17.0
 opentelemetry-api>=1.20.0
 opentelemetry-sdk>=1.20.0
-opentelemetry-exporter-prometheus>=0.58.0  # Compatible with Python 3.9
-opentelemetry-exporter-cloud-trace>=1.0.0
+opentelemetry-exporter-prometheus==0.58b0  # Compatible with Python 3.12
+opentelemetry-exporter-gcp-trace>=1.0.0
 opentelemetry-instrumentation>=0.40b0
 
 # Production web framework


### PR DESCRIPTION
- Updated `opentelemetry-exporter-prometheus` to version `0.58b0` which is compatible with Python 3.12.
- Replaced `opentelemetry-exporter-cloud-trace` with `opentelemetry-exporter-gcp-trace` as the former is deprecated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated monitoring dependencies, pinning the Prometheus exporter to an exact version compatible with Python 3.12.
  - Replaced the legacy Cloud Trace exporter with the Google Cloud Trace exporter.
  - Retained existing OpenTelemetry core packages without changes.

- Compatibility
  - Monitoring stack now targets Python 3.12.

- Notes
  - These changes affect production monitoring dependencies only and do not alter application features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->